### PR TITLE
IPV6: Fix build with unmeet dependendes when disable ipv6

### DIFF
--- a/agent/mibgroup/mibII/vacm_conf.c
+++ b/agent/mibgroup/mibII/vacm_conf.c
@@ -977,6 +977,7 @@ vacm_create_simple(const char *token, char *confline,
 #endif
 
 #ifdef NETSNMP_TRANSPORT_UDPIPV6_DOMAIN
+#ifdef NETSNMP_ENABLE_IPV6
     if (parsetype == VACM_CREATE_SIMPLE_COMIPV6 ||
         parsetype == VACM_CREATE_SIMPLE_COM) {
         vacm_gen_com2sec(commcount, community, addressname,
@@ -984,6 +985,7 @@ vacm_create_simple(const char *token, char *confline,
                          secname, sizeof(secname),
                          view_ptr, sizeof(viewname), commversion, context);
     }
+#endif
 #endif
 #endif /* support for community based SNMP */
 

--- a/snmplib/Makefile.in
+++ b/snmplib/Makefile.in
@@ -157,6 +157,7 @@ CSRCS=	snmp_client.c mib.c parse.c snmp_api.c snmp.c 		\
 	snmp_secmod.c @security_src_list@ snmp_version.c        \
 	container_null.c container_list_ssll.c container_iterator.c \
 	ucd_compat.c		                                \
+	inet_ntop.c inet_pton.c					\
 	@other_src_list@ @crypto_files_c@        		\
 	dir_utils.c file_utils.c 	                        \
 	container.c container_binary_array.c	
@@ -176,6 +177,7 @@ OBJS=	snmp_client.o mib.o parse.o snmp_api.o snmp.o 		\
 	snmp_secmod.o @security_obj_list@ snmp_version.o        \
 	container_null.o container_list_ssll.o container_iterator.o \
 	ucd_compat.o                               		\
+	inet_ntop.o inet_pton.o					\
         @crypto_files_o@ @other_objs_list@ @LIBOBJS@ 		\
 	dir_utils.o file_utils.o 	                        \
 	container.o container_binary_array.o	
@@ -195,6 +197,7 @@ LOBJS=	snmp_client.lo mib.lo parse.lo snmp_api.lo snmp.lo 	\
 	snmp_secmod.lo @security_lobj_list@ snmp_version.lo     \
 	container.lo container_binary_array.lo			\
 	ucd_compat.lo		                                \
+	inet_ntop.lo inet_pton.lo				\
         @crypto_files_lo@ @other_lobjs_list@ @LTLIBOBJS@        \
 	dir_utils.lo file_utils.lo 	                        \
 	container_null.lo container_list_ssll.lo container_iterator.lo 
@@ -213,6 +216,7 @@ FTOBJS=	snmp_client.ft mib.ft parse.ft snmp_api.ft snmp.ft 	\
 	snmp_secmod.ft @security_ftobj_list@ snmp_version.ft    \
 	container.ft container_binary_array.ft	\
 	ucd_compat.ft		                             	\
+	inet_ntop.ft inet_pton.ft				\
         @other_ftobjs_list@                     		\
 	large_fd_set.ft cert_util.ft snmp_openssl.ft 		\
 	dir_utils.ft file_utils.ft 	                        \


### PR DESCRIPTION
Hi,

I encountered unresolved symbol issues when compiling without IPv6 support under MinGW then Linux :

    $ CC=x86_64-w64-mingw32-gcc ./configure --host x86_64-w64-mingw32 --disable-embedded-perl --without-perl-modules --enable-static --disable-shared --disable-ipv6
    (...)
    $ make
    (...)
    libtool: link: x86_64-w64-mingw32-gcc -g -O2 -fno-strict-aliasing -DNETSNMP_REMOVE_U64 -g -O2 -Umingw32 -Dmingw32=mingw32 -Wall -Wextra -Wstrict-prototypes -Wwrite-strings -Wcast-qual -Wimplicit-fallthrough=2 -Wlogical-op -Wundef -Wno-format-truncation -Wno-missing-field-initializers -Wno-sign-compare -Wno-unused-parameter -o snmpd.exe snmpd.o ../snmplib/winservicerc.o  ./.libs/libnetsnmpagent.a ./.libs/libnetsnmpmibs.a /tmp/net-snmp/agent/.libs/libnetsnmpagent.a -lnetapi32 /tmp/net-snmp/snmplib/.libs/libnetsnmp.a ../snmplib/.libs/libnetsnmp.a -lcrypto -lws2_32 -liphlpapi -lregex -lsnmpapi
    /usr/lib/gcc/x86_64-w64-mingw32/9.2.1/../../../../x86_64-w64-mingw32/bin/ld: /tmp/net-snmp/snmplib/.libs/libnetsnmp.a(system.o): in function `netsnmp_getaddrinfo':
    /tmp/net-snmp/snmplib/system.c:933: undefined reference to `netsnmp_inet_ntop'
    /usr/lib/gcc/x86_64-w64-mingw32/9.2.1/../../../../x86_64-w64-mingw32/bin/ld: /tmp/net-snmp/snmplib/system.c:924: undefined reference to `netsnmp_inet_ntop'
    /usr/lib/gcc/x86_64-w64-mingw32/9.2.1/../../../../x86_64-w64-mingw32/bin/ld: /tmp/net-snmp/snmplib/.libs/libnetsnmp.a(snmpUDPDomain.o): in function `netsnmp_udp_com2SecEntry_create':
    /tmp/net-snmp/snmplib/transports/snmpUDPDomain.c:262: undefined reference to `netsnmp_inet_ntop'
    /usr/lib/gcc/x86_64-w64-mingw32/9.2.1/../../../../x86_64-w64-mingw32/bin/ld: /tmp/net-snmp/snmplib/transports/snmpUDPDomain.c:262: undefined reference to `netsnmp_inet_ntop'
    /usr/lib/gcc/x86_64-w64-mingw32/9.2.1/../../../../x86_64-w64-mingw32/bin/ld: /tmp/net-snmp/snmplib/transports/snmpUDPDomain.c:262: undefined reference to `netsnmp_inet_ntop'
    /usr/lib/gcc/x86_64-w64-mingw32/9.2.1/../../../../x86_64-w64-mingw32/bin/ld: /tmp/net-snmp/snmplib/.libs/libnetsnmp.a(snmpUDPDomain.o):/tmp/net-snmp/snmplib/transports/snmpUDPDomain.c:262: more undefined references to `netsnmp_inet_ntop' follow
    /usr/lib/gcc/x86_64-w64-mingw32/9.2.1/../../../../x86_64-w64-mingw32/bin/ld: /tmp/net-snmp/snmplib/.libs/libnetsnmp.a(snmpUDPDomain.o): in function `netsnmp_udp_parse_security':
    /tmp/net-snmp/snmplib/transports/snmpUDPDomain.c:386: undefined reference to `netsnmp_inet_pton'
    /usr/lib/gcc/x86_64-w64-mingw32/9.2.1/../../../../x86_64-w64-mingw32/bin/ld: /tmp/net-snmp/snmplib/transports/snmpUDPDomain.c:386: undefined reference to `netsnmp_inet_pton'
    /usr/lib/gcc/x86_64-w64-mingw32/9.2.1/../../../../x86_64-w64-mingw32/bin/ld: /tmp/net-snmp/snmplib/transports/snmpUDPDomain.c:414: undefined reference to `netsnmp_inet_pton'
    /usr/lib/gcc/x86_64-w64-mingw32/9.2.1/../../../../x86_64-w64-mingw32/bin/ld: /tmp/net-snmp/snmplib/.libs/libnetsnmp.a(snmpUDPDomain.o): in function `netsnmp_udp_getSecName':
    /tmp/net-snmp/snmplib/transports/snmpUDPDomain.c:571: undefined reference to `netsnmp_inet_ntop'
    /usr/lib/gcc/x86_64-w64-mingw32/9.2.1/../../../../x86_64-w64-mingw32/bin/ld: /tmp/net-snmp/snmplib/transports/snmpUDPDomain.c:571: undefined reference to `netsnmp_inet_ntop'
    /usr/lib/gcc/x86_64-w64-mingw32/9.2.1/../../../../x86_64-w64-mingw32/bin/ld: /tmp/net-snmp/snmplib/transports/snmpUDPDomain.c:571: undefined reference to `netsnmp_inet_ntop'
    /usr/lib/gcc/x86_64-w64-mingw32/9.2.1/../../../../x86_64-w64-mingw32/bin/ld: /tmp/net-snmp/snmplib/transports/snmpUDPDomain.c:571: undefined reference to `netsnmp_inet_ntop'
    /usr/lib/gcc/x86_64-w64-mingw32/9.2.1/../../../../x86_64-w64-mingw32/bin/ld: /tmp/net-snmp/snmplib/.libs/libnetsnmp.a(snmpIPv4BaseDomain.o): in function `netsnmp_ipv4_fmtaddr':
    /tmp/net-snmp/snmplib/transports/snmpIPv4BaseDomain.c:196: undefined reference to `netsnmp_inet_ntop'
    /usr/lib/gcc/x86_64-w64-mingw32/9.2.1/../../../../x86_64-w64-mingw32/bin/ld: /tmp/net-snmp/snmplib/.libs/libnetsnmp.a(snmpIPv4BaseDomain.o):/tmp/net-snmp/snmplib/transports/snmpIPv4BaseDomain.c:196: more undefined references to `netsnmp_inet_ntop' follow
    collect2: error: ld returned 1 exit status
    
    $ ./configure --with-defaults --disable-shared --enable-static --disable-ipv6
    (...)
    $ make
    (...)
    libtool: link: gcc -g -O2 -fno-strict-aliasing -DNETSNMP_REMOVE_U64 -g -O2 -Ulinux -Dlinux=linux -Wall -Wextra -Wstrict-prototypes -Wwrite-strings -Wcast-qual -Wimplicit-fallthrough=2 -Wlogical-op -Wundef -Wno-format-truncation -Wno-missing-field-initializers -Wno-sign-compare -Wno-unused-parameter -o snmpd snmpd.o  ./.libs/libnetsnmpagent.a ./.libs/libnetsnmpmibs.a /tmp/net-snmp/agent/.libs/libnetsnmpagent.a /tmp/net-snmp/snmplib/.libs/libnetsnmp.a -ldl -lrpm -lrpmio ../snmplib/.libs/libnetsnmp.a -lm -lcrypto
    /usr/bin/ld: ./.libs/libnetsnmpagent.a(vacm_conf.o): in function `vacm_create_simple':
    /tmp/net-snmp/agent/mibgroup/mibII/vacm_conf.c:982: undefined reference to `netsnmp_udp6_parse_security'
    /usr/bin/ld: ./.libs/libnetsnmpagent.a(vacm_conf.o): in function `vacm_check_view_contents':
    /tmp/net-snmp/agent/mibgroup/mibII/vacm_conf.c:1345: undefined reference to `netsnmp_UDPIPv6Domain'
    /usr/bin/ld: /tmp/net-snmp/agent/mibgroup/mibII/vacm_conf.c:1345: undefined reference to `netsnmp_TCPIPv6Domain'
    /usr/bin/ld: /tmp/net-snmp/agent/mibgroup/mibII/vacm_conf.c:1348: undefined reference to `netsnmp_udp6_getSecName'

